### PR TITLE
Added try-catch to ScriptEngine.cs

### DIFF
--- a/src/ScriptEngine/ScriptEngine.cs
+++ b/src/ScriptEngine/ScriptEngine.cs
@@ -98,13 +98,10 @@ namespace ScriptEngine
                     catch (ReflectionTypeLoadException e)
                     {
                         var sbMessage = new StringBuilder();
-                        sbMessage.AppendLine($"Error While loading {path}");
-                        sbMessage.AppendLine("-- Successfully Read Types --");
-                        foreach (var t in e.Types)
-                            if (t != null) sbMessage.AppendLine(t.ToString());
+                        sbMessage.AppendLine($"Error while loading {path}");
                         sbMessage.AppendLine("\r\n-- LoaderExceptions --");
                         foreach (var l in e.LoaderExceptions)
-                            if (l != null) sbMessage.AppendLine(l.ToString());
+                            sbMessage.AppendLine(l.ToString());
                         sbMessage.AppendLine("\r\n-- StackTrace --");
                         sbMessage.AppendLine(e.StackTrace);
                         Logger.LogError(sbMessage.ToString());

--- a/src/ScriptEngine/ScriptEngine.cs
+++ b/src/ScriptEngine/ScriptEngine.cs
@@ -97,11 +97,17 @@ namespace ScriptEngine
                     }
                     catch (ReflectionTypeLoadException e)
                     {
-                        StringBuilder strTypes = new StringBuilder();
-                        foreach (var t in e.Types) { strTypes.Append(t + "\r\n"); }
-                        StringBuilder strExceptions = new StringBuilder();
-                        foreach (var l in e.LoaderExceptions) { strExceptions.Append(l + "\r\n"); }
-                        Logger.LogError($"Error While loading {path} \r\n -- Types --\r\n{strTypes}\r\n-- LoaderExceptions --\r\n{strExceptions}\r\n -- StackTrace --\r\n{e.StackTrace}");
+                        var sbMessage = new StringBuilder();
+                        sbMessage.AppendLine($"Error While loading {path}");
+                        sbMessage.AppendLine("-- Successfully Read Types --");
+                        foreach (var t in e.Types)
+                            if (t != null) sbMessage.AppendLine(t.ToString());
+                        sbMessage.AppendLine("\r\n-- LoaderExceptions --");
+                        foreach (var l in e.LoaderExceptions)
+                            if (l != null) sbMessage.AppendLine(l.ToString());
+                        sbMessage.AppendLine("\r\n-- StackTrace --");
+                        sbMessage.AppendLine(e.StackTrace);
+                        Logger.LogError(sbMessage.ToString());
                     }
                 }
             }


### PR DESCRIPTION
Added try-catch to display helpful log for investigation when dll files could not be reloaded.

- Before
```
[Error  : Unity Log] ReflectionTypeLoadException: The classes in the module cannot be loaded.
Stack trace:
System.Reflection.Assembly.GetTypes ()
ScriptEngine.ScriptEngine.LoadDLL (System.String path, UnityEngine.GameObject obj)
ScriptEngine.ScriptEngine.ReloadPlugins ()
ScriptEngine.ScriptEngine.Update ()
```

- After
```
[Error  :Script Engine] Error While loading C:\(path)\BepInEx\scripts\BepInEx.ScriptSelector.dll
-- Successfully Read Types --
ScriptSelector.MonoCompiler

ScriptSelector.ScriptInfo
ScriptSelector.ScriptInfo+<>c
ScriptSelector.ScriptSelector
ScriptSelector.ScriptSelector+<>c__DisplayClass10_0
ScriptSelector.ScriptSelector+<>c
ScriptSelector.LoggerTextWriter
ScriptSelector.Utilities

-- LoaderExceptions --
System.TypeLoadException: Could not load type '<>c__DisplayClass2_0' from assembly 'BepInEx.ScriptSelector-637339073995094410, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.

-- StackTrace --
  at (wrapper managed-to-native) System.Reflection.Assembly:GetTypes (bool)
  at System.Reflection.Assembly.GetTypes () [0x00000] in <filename unknown>:0
  at ScriptEngine.ScriptEngine.LoadDLL (System.String path, UnityEngine.GameObject obj) [0x00000] in <filename unknown>:0
```