### PR TITLE
SimpleProfiler: fix bug where each method was measured only once

### DIFF
--- a/src/SimpleProfiler/MonoProfiler/dllmain.cpp
+++ b/src/SimpleProfiler/MonoProfiler/dllmain.cpp
@@ -57,7 +57,10 @@ static void method_enter(void* prof, void* method)
 		if (it == profilerInfo.end())
 			profilerInfo[method] = ProfilerInfo(method);
 		else
+		{
 			it->second.calls++;
+			it->second.push_thread();
+		}
 	}
 	mut.unlock();
 }


### PR DESCRIPTION
This resulted in the Total runtime column of the CSV to have much smaller numbers than it should.