### PR TITLE
SimpleProfiler: add allocation and thread columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You can use LibreOffice Calc or Excel to view the dumped .csv results. Using Cal
 
 **Warning:** The profiler always runs and will noticeably slow down the game. To turn the profiler off you have to close the game and rename MonoProfiler dll to something else like `_MonoProfiler32.dll`. You need the correct version of `MonoProfiler.dll` for your game (either 32 or 64 bit).
 
+**Warning:** Due to the way allocations are measured, the provided numbers are just rough estimates. In particular, any allocations that happen in other threads during the runtime of the method are usually included in the number.
+
 ### ScriptEngine
 Loads and reloads BepInEx plugins from the `BepInEx\scripts` folder. User can reload all of these plugins by pressing the keyboard shortcut defined in the config. Shortcut is F6 by default.  
 Very useful for quickly developing plugins as you don't have to keep reopening the game to see your changes.

--- a/src/SimpleProfiler/MonoProfiler/dllmain.h
+++ b/src/SimpleProfiler/MonoProfiler/dllmain.h
@@ -122,6 +122,7 @@ typedef void (*MonoProfileMethodFunc)(void* prof, void* method);
 MONO_FUN(mono_profiler_install, void, void* prof, MonoProfileFunc shutdown_callback);
 MONO_FUN(mono_profiler_set_events, void, MonoProfileFlags events);
 MONO_FUN(mono_profiler_install_enter_leave, void, MonoProfileMethodFunc enter, MonoProfileMethodFunc fleave);
+MONO_FUN(mono_gc_get_used_size, uint64_t);
 
 inline void init_mono_funcs(HMODULE mono)
 {
@@ -132,6 +133,7 @@ inline void init_mono_funcs(HMODULE mono)
 	GET_FUN(mono_profiler_set_events);
 	GET_FUN(mono_profiler_install_enter_leave);
 	GET_FUN(mono_thread_current);
+	GET_FUN(mono_gc_get_used_size);
 
 #undef GET_FUN
 }

--- a/src/SimpleProfiler/MonoProfiler/dllmain.h
+++ b/src/SimpleProfiler/MonoProfiler/dllmain.h
@@ -6,8 +6,6 @@
 #include <time.h>
 #include <Windows.h> // Windows Platform SDK
 
-using namespace std::chrono;
-
 #define MONO_FUN(name, ret, ...) \
 	typedef ret (*name##_t)(__VA_ARGS__); \
 	static name##_t name;
@@ -85,46 +83,12 @@ struct _MonoThread {
 MONO_FUN(mono_thread_current, _MonoThread*);
 MONO_FUN(mono_method_full_name, char*, void* method);
 
-struct ProfilerInfo
-{
-	std::map<uint32_t, time_point<steady_clock>> threadTiming;
-
-	char* name;
-	uint64_t calls = 1;
-
-	nanoseconds totalRuntime = nanoseconds(0);
-
-	ProfilerInfo() : name((char*)"__NULL__") { }
-
-	ProfilerInfo(void* method)
-	{
-		name = mono_method_full_name(method);
-		push_thread();
-	}
-
-	void push_thread()
-	{
-		threadTiming[mono_thread_current()->small_id] = high_resolution_clock::now();
-	}
-
-	void pop_thread()
-	{
-		auto k = threadTiming.find(mono_thread_current()->small_id);
-		if (k != threadTiming.end())
-		{
-			totalRuntime += (high_resolution_clock::now() - k->second);
-			threadTiming.erase(k);
-		}
-	}
-};
-
 //struct MonoProfiler
 //{
 //	std::map<void*, ProfilerInfo> profilerInfo;
 //};
 
 //static MonoProfiler* prof;
-static std::map<void*, ProfilerInfo> profilerInfo;
 
 typedef enum
 {


### PR DESCRIPTION
This branch adds two columns to the generated CSV file: allocation and thread.

This branch contains 3 commits. Each commit is self-contained but depends on the previous ones. Let me know if you'd rather have 3 separate pull requests.

* The first commit partially rewrites code for efficiency. It reduces profiling overhead by 65% or so in my tests.
* The second commit adds allocation numbers. It increases overhead by about 10%.
* The third commit adds a Thread column. This changes how numbers are broken down, so it's a breaking change in a sense.