### PR TITLE
ScriptEngine: added FileSystemWatcher, optionally including subdirectories and…

### DIFF
--- a/src/ScriptEngine/ScriptEngine.cs
+++ b/src/ScriptEngine/ScriptEngine.cs
@@ -42,8 +42,8 @@ namespace ScriptEngine
             LoadOnStart = Config.Bind("General", "LoadOnStart", false, new ConfigDescription("Load all plugins from the scripts folder when starting the application"));
             ReloadKey = Config.Bind("General", "ReloadKey", new KeyboardShortcut(KeyCode.F6), new ConfigDescription("Press this key to reload all the plugins from the scripts folder"));
             QuietMode = Config.Bind("General", "QuietMode", false, new ConfigDescription("Suppress sending log messages to console except for the error ones."));
-            EnableFileSystemWatcher = Config.Bind("General", "EnableFileSystemWatcher", false, new ConfigDescription("Listens for changes to the scripts directory and reloads all plugins automatically."));
-            IncludeSubdirectories = Config.Bind("General", "IncludeSubdirectories", false, new ConfigDescription("Include also subdirectories under the scripts folder."));
+            EnableFileSystemWatcher = Config.Bind("General", "EnableFileSystemWatcher", false, new ConfigDescription("Watches the scripts directory for file changes and reloads all plugins if any of them gets changed."));
+            IncludeSubdirectories = Config.Bind("General", "IncludeSubdirectories", false, new ConfigDescription("Also include subdirectories under the scripts folder."));
 
             if (LoadOnStart.Value)
                 ReloadPlugins();

--- a/src/ScriptEngine/ScriptEngine.cs
+++ b/src/ScriptEngine/ScriptEngine.cs
@@ -27,40 +27,58 @@ namespace ScriptEngine
 
         ConfigEntry<bool> LoadOnStart { get; set; }
         ConfigEntry<KeyboardShortcut> ReloadKey { get; set; }
+        
+        // FS Watcher EDIT
+        ConfigEntry<bool> QuietMode { get; set; }
+        ConfigEntry<bool> EnableFileSystemWatcher { get; set; }
+        ConfigEntry<bool> IncludeSubdirectories { get; set; }
+        
+        private FileSystemWatcher fileSystemWatcher;
+        private bool shouldReload;
+        //
 
         void Awake()
         {
             LoadOnStart = Config.Bind("General", "LoadOnStart", false, new ConfigDescription("Load all plugins from the scripts folder when starting the application"));
             ReloadKey = Config.Bind("General", "ReloadKey", new KeyboardShortcut(KeyCode.F6), new ConfigDescription("Press this key to reload all the plugins from the scripts folder"));
+            QuietMode = Config.Bind("General", "QuietMode", false, new ConfigDescription("Suppress sending log messages to console except for the error ones."));
+            EnableFileSystemWatcher = Config.Bind("General", "EnableFileSystemWatcher", false, new ConfigDescription("Listens for changes to the scripts directory and reloads all plugins automatically."));
+            IncludeSubdirectories = Config.Bind("General", "IncludeSubdirectories", false, new ConfigDescription("Include also subdirectories under the scripts folder."));
 
             if (LoadOnStart.Value)
                 ReloadPlugins();
+
+            StartFileSystemWatcher();
         }
 
         void Update()
         {
-            if (ReloadKey.Value.IsDown())
+            if (shouldReload || ReloadKey.Value.IsDown())
                 ReloadPlugins();
         }
 
         void ReloadPlugins()
         {
-            Logger.Log(LogLevel.Info, "Unloading old plugin instances");
+            shouldReload = false;
+            if (!QuietMode.Value)
+                Logger.Log(LogLevel.Info, "Unloading old plugin instances");
             Destroy(scriptManager);
             scriptManager = new GameObject($"ScriptEngine_{DateTime.Now.Ticks}");
             DontDestroyOnLoad(scriptManager);
 
-            var files = Directory.GetFiles(ScriptDirectory, "*.dll");
+            var files = Directory.GetFiles(ScriptDirectory, "*.dll", IncludeSubdirectories.Value ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
             if (files.Length > 0)
             {
-                foreach (string path in Directory.GetFiles(ScriptDirectory, "*.dll"))
+                foreach (string path in Directory.GetFiles(ScriptDirectory, "*.dll", IncludeSubdirectories.Value ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly))
                     LoadDLL(path, scriptManager);
 
-                Logger.LogMessage("Reloaded all plugins!");
+                if (!QuietMode.Value)
+                    Logger.LogMessage("Reloaded all plugins!");
             }
             else
             {
-                Logger.LogMessage("No plugins to reload");
+                if (!QuietMode.Value)
+                    Logger.LogMessage("No plugins to reload");
             }
         }
 
@@ -71,7 +89,8 @@ namespace ScriptEngine
             defaultResolver.AddSearchDirectory(Paths.ManagedPath);
             defaultResolver.AddSearchDirectory(Paths.BepInExAssemblyDirectory);
 
-            Logger.Log(LogLevel.Info, $"Loading plugins from {path}");
+            if (!QuietMode.Value)
+                Logger.Log(LogLevel.Info, $"Loading plugins from {path}");
 
             using (var dll = AssemblyDefinition.ReadAssembly(path, new ReaderParameters { AssemblyResolver = defaultResolver }))
             {
@@ -95,7 +114,8 @@ namespace ScriptEngine
                                     var typeInfo = Chainloader.ToPluginInfo(typeDefinition);
                                     Chainloader.PluginInfos[metadata.GUID] = typeInfo;
 
-                                    Logger.Log(LogLevel.Info, $"Loading {metadata.GUID}");
+                                    if (!QuietMode.Value)
+                                        Logger.Log(LogLevel.Info, $"Loading {metadata.GUID}");
                                     StartCoroutine(DelayAction(() =>
                                     {
                                         try
@@ -119,6 +139,41 @@ namespace ScriptEngine
             }
         }
 
+        private void StartFileSystemWatcher()
+        {
+            fileSystemWatcher = new FileSystemWatcher(ScriptDirectory)
+            {
+                IncludeSubdirectories = IncludeSubdirectories.Value
+            };
+            fileSystemWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName;
+            fileSystemWatcher.Filter = "*.dll";
+            fileSystemWatcher.Changed += (sender, args) =>
+            {
+                if (!QuietMode.Value)
+                    Logger.LogInfo($"File {Path.GetFileName(args.Name)} changed. Recompiling...");
+                shouldReload = true;
+            };
+            fileSystemWatcher.Deleted += (sender, args) =>
+            {
+                if (!QuietMode.Value)
+                    Logger.LogInfo($"File {Path.GetFileName(args.Name)} removed. Recompiling...");
+                shouldReload = true;
+            };
+            fileSystemWatcher.Created += (sender, args) =>
+            {
+                if (!QuietMode.Value)
+                    Logger.LogInfo($"File {Path.GetFileName(args.Name)} created. Recompiling...");
+                shouldReload = true;
+            };
+            fileSystemWatcher.Renamed += (sender, args) =>
+            {
+                if (!QuietMode.Value)
+                    Logger.LogInfo($"File {Path.GetFileName(args.Name)} renamed. Recompiling...");
+                shouldReload = true;
+            };
+            fileSystemWatcher.EnableRaisingEvents = true;
+        }
+        
         private IEnumerable<Type> GetTypesSafe(Assembly ass)
         {
             try

--- a/src/ScriptEngine/ScriptEngine.cs
+++ b/src/ScriptEngine/ScriptEngine.cs
@@ -48,7 +48,8 @@ namespace ScriptEngine
             if (LoadOnStart.Value)
                 ReloadPlugins();
 
-            StartFileSystemWatcher();
+            if (EnableFileSystemWatcher.Value)
+                StartFileSystemWatcher();
         }
 
         void Update()

--- a/src/ScriptEngine/ScriptEngine.cs
+++ b/src/ScriptEngine/ScriptEngine.cs
@@ -156,35 +156,19 @@ namespace ScriptEngine
             };
             fileSystemWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName;
             fileSystemWatcher.Filter = "*.dll";
-            fileSystemWatcher.Changed += (sender, args) =>
-            {
-                if (!QuietMode.Value)
-                    Logger.LogInfo($"File {Path.GetFileName(args.Name)} changed. Recompiling...");
-                shouldReload = true;
-                autoReloadTimer = AutoReloadDelay.Value;
-            };
-            fileSystemWatcher.Deleted += (sender, args) =>
-            {
-                if (!QuietMode.Value)
-                    Logger.LogInfo($"File {Path.GetFileName(args.Name)} removed. Recompiling...");
-                shouldReload = true;
-                autoReloadTimer = AutoReloadDelay.Value;
-            };
-            fileSystemWatcher.Created += (sender, args) =>
-            {
-                if (!QuietMode.Value)
-                    Logger.LogInfo($"File {Path.GetFileName(args.Name)} created. Recompiling...");
-                shouldReload = true;
-                autoReloadTimer = AutoReloadDelay.Value;
-            };
-            fileSystemWatcher.Renamed += (sender, args) =>
-            {
-                if (!QuietMode.Value)
-                    Logger.LogInfo($"File {Path.GetFileName(args.Name)} renamed. Recompiling...");
-                shouldReload = true;
-                autoReloadTimer = AutoReloadDelay.Value;
-            };
+            fileSystemWatcher.Changed += FileChangedEventHandler;
+            fileSystemWatcher.Deleted += FileChangedEventHandler;
+            fileSystemWatcher.Created += FileChangedEventHandler;
+            fileSystemWatcher.Renamed += FileChangedEventHandler;
             fileSystemWatcher.EnableRaisingEvents = true;
+        }
+        
+        private void FileChangedEventHandler(object sender, FileSystemEventArgs args)
+        {
+            if (!QuietMode.Value)
+                Logger.LogInfo($"File {Path.GetFileName(args.Name)} changed. Delayed recompiling...");
+            shouldReload = true;
+            autoReloadTimer = AutoReloadDelay.Value;
         }
         
         private IEnumerable<Type> GetTypesSafe(Assembly ass)


### PR DESCRIPTION
The entries added to the `com.bepis.bepinex.scriptengine.cfg` file can be used as this PR's description:

```ini
## Suppress sending log messages to console except for the error ones.
# Setting type: Boolean
# Default value: false
QuietMode = true

## Listens for changes to the scripts directory and reloads all plugins automatically.
# Setting type: Boolean
# Default value: false
EnableFileSystemWatcher = true

## Include also subdirectories under the scripts folder.
# Setting type: Boolean
# Default value: false
IncludeSubdirectories = true
```