### PR TITLE
[Docs] Add "Troubleshooting" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,6 @@ https://github.com/risk-of-thunder/R2Wiki/wiki/Debugging-Your-Mods-With-dnSpy
 ### Runtime Unity Editor
 In-game inspector, editor and interactive console for applications made with Unity3D game engine. It's designed for debugging and modding Unity games.  
 https://github.com/ManlyMarco/RuntimeUnityEditor#readme
+
+## Troubleshooting
+- The BepInEx plugin manager object is destroyed early in certain games which aggressively clean up scenes, causing some plugins to not work. This can be fixed by setting the `HideManagerGameObject` option to `true` in `BepInEx/config/BepInEx.cfg`.


### PR DESCRIPTION
As mentioned [here](https://github.com/BepInEx/BepInEx/issues/420#issuecomment-1139502138), the BepInEx plugin manager object is destroyed early in certain games which aggressively clean up scenes. For instance, this is a problem in ScriptEngine because it reloads the plugins in the `Update()` method, which is never called in these games. Fortunately, setting `HideManagerGameObject` to `true` in `BepInEx.cfg` solves this issue.

I only tested ScriptEngine, but other plugins might have this issue as well, which is why I thought it'd be helpful to have a troubleshooting section in the README for issues like this one. I already included the issue mentioned earlier and its solution in this PR. Let me know what you think 😄 