### PR TITLE
ScriptEngine: Add assembly dumping setting for debugging of reloaded plugins

### DIFF
--- a/src/ScriptEngine/ScriptEngine.cs
+++ b/src/ScriptEngine/ScriptEngine.cs
@@ -13,9 +13,6 @@ using System.Text;
 using Common;
 using HarmonyLib;
 using UnityEngine;
-using System.Security.Cryptography;
-using UnityEngine.Networking.Types;
-using System.Diagnostics;
 
 namespace ScriptEngine
 {

--- a/src/ScriptEngine/ScriptEngine.cs
+++ b/src/ScriptEngine/ScriptEngine.cs
@@ -144,10 +144,10 @@ namespace ScriptEngine
                             WriteSymbols = true
                         });
                     }
-                    Logger.Log(LogLevel.Info, $"Dumped Assembly & Symbols to {assemblyDumpPath}");
 
                     ass = Assembly.LoadFile(assemblyDumpPath);
-                    Logger.Log(LogLevel.Info, $"Loaded dumped Assembly from {assemblyDumpPath}");
+                    if (!QuietMode.Value)
+                        Logger.Log(LogLevel.Info, $"Loaded dumped Assembly from {assemblyDumpPath}");
                 } else
                 {
                     // Load from memory


### PR DESCRIPTION
Similarly to the LoadDumpedAssemblies BepInEx Preloader option, this adds a config option which dumps Assemblies & Symbols to the disk.
The assemblies are then loaded from the saved dll so that debuggers can then load the matching symbols & break/step through plugin code.

Tested successfully on Rider but should work for all debuggers that are configured to read symbols from the BepInEx folder.